### PR TITLE
set print.class=FALSE before test

### DIFF
--- a/inst/tinytest/test_0-dict.table.R
+++ b/inst/tinytest/test_0-dict.table.R
@@ -127,6 +127,7 @@ expect_true(identical(dit, dit.copy)) # dit.copy has not changed
 
 # dict.table can be printed
 dit = dict.table(A = 1:2, B = 2:1)
+options(datatable.print.class=FALSE)
 out <- capture.output(print(dit))
 out.expected <- c("<dict.table> with 2 rows and 2 columns",
                   "   A B",


### PR DESCRIPTION
hi @rpahl 
When `data.table` from github master is installed, `data.table::update_dev_pkg()` container has a new test failure, https://github.com/Rdatatable/data.table/issues/5535 because the new default is `options(datatable.print.class=TRUE)` whereas it was previously FALSE.
This PR provides a fix for your test, by setting the option to the old default before running the test.
You may also consider simply removing this test (it is not good practice to test the printed output), or grep for the specific substring you are looking for in the output, instead of testing equality of the entire output.